### PR TITLE
Add Write endpoint for Courses

### DIFF
--- a/google_classroom/endpoints/course.py
+++ b/google_classroom/endpoints/course.py
@@ -39,3 +39,7 @@ class Courses(EndPoint):
         df = df.rename(columns={"id": "courseId"})
         df = df[["courseId", "name", "section"]]
         return df.astype("str")
+
+    def create_new_item(self, course):
+        course["courseState"] = "ACTIVE"
+        return self.service.courses().create(body=course)

--- a/google_classroom/main.py
+++ b/google_classroom/main.py
@@ -162,8 +162,7 @@ def pull_data(config, creds, sql):
 
 def sync_all_data(config, creds, sql):
     classroom_service = build("classroom", "v1", credentials=creds)
-    (to_create, to_delete) = Courses(classroom_service, sql, config).sync_data()
-    print("Data syncing is not yet available.")
+    Courses(classroom_service, sql, config).sync_data()
 
 
 if __name__ == "__main__":

--- a/google_classroom/sync_files/courses_sample.csv
+++ b/google_classroom/sync_files/courses_sample.csv
@@ -1,4 +1,4 @@
 alias,name,section,teacher_email
-25601,Literature,1,teacher1@gmail.com
-25602,English,2,teacher2@gmail.com
-25603,Biology,3,teacher3@gmail.com
+99997,Literature,1,teacher1@gmail.com
+99998,English,2,teacher2@gmail.com
+99999,Biology,3,teacher3@gmail.com

--- a/tests/mock_response.py
+++ b/tests/mock_response.py
@@ -56,6 +56,15 @@ class FakeRequest:
         return self.result
 
 
+class FakeCreateRequest:
+    def __init__(self, *args, **kwargs):
+        self.args = args
+        self.kwargs = kwargs
+
+    def execute(self):
+        pass
+
+
 class FakeEndpoint:
     def __init__(self, result):
         self.result = result
@@ -65,6 +74,9 @@ class FakeEndpoint:
 
     def get(self, *args, **kwargs):
         return FakeRequest(self.result, *args, **kwargs)
+
+    def create(self, *args, **kwargs):
+        return FakeCreateRequest(*args, **kwargs)
 
 
 class FakeService:

--- a/tests/sync_data.py
+++ b/tests/sync_data.py
@@ -32,10 +32,10 @@ SOURCE_DATA = pd.DataFrame(
 
 TO_CREATE_SOLUTION = pd.DataFrame(
     {
-        "alias": ["d:678", "d:789"],
+        "id": ["d:678", "d:789"],
         "name": ["History", "Computer Science"],
         "section": ["2", "2"],
-        "teacher_email": ["a@b.com", "a@b.com"],
+        "ownerId": ["a@b.com", "a@b.com"],
     }
 )
 TO_DELETE_SOLUTION = pd.DataFrame(


### PR DESCRIPTION
Depends on #98 
Fixes #86 

Adds the first sync endpoint, for Courses. Note that this doesn't handle errors or batching, which will come in the next PR so that the code can be shared with the existing batching code.

A few things are renamed to match the endpoint more accurately.