### PR TITLE
Adds batch logic to course creation

### DIFF
--- a/google_classroom/config.py
+++ b/google_classroom/config.py
@@ -128,6 +128,7 @@ class Config(object):
     INVITATIONS_BATCH_SIZE = int(os.getenv("INVITATIONS_BATCH_SIZE") or 1000)
     ANNOUNCEMENTS_BATCH_SIZE = int(os.getenv("ANNOUNCEMENTS_BATCH_SIZE") or 1000)
     MEET_BATCH_SIZE = int(os.getenv("MEET_BATCH_SIZE") or 1000)
+    SYNC_BATCH_SIZE = 5
     PAGE_SIZE = int(os.getenv("PAGE_SIZE") or 1000)
 
 

--- a/google_classroom/endpoints/base.py
+++ b/google_classroom/endpoints/base.py
@@ -345,9 +345,64 @@ class EndPoint:
         )
         to_delete = db_df[db_df.alias.isin(right_only.alias)].reset_index(drop=True)
 
-        for item in to_create.to_dict(orient="records"):
+        batch_results = []
+        quota_exceeded = False
+        remaining_requests = []
+        request_index = {}
+
+        if len(to_create) == 0:
+            logging.info(f"{self.classname()}: No new items to create.")
+            return
+
+        for idx, item in enumerate(to_create.to_dict(orient="records")):
             request = self.create_new_item(item)
-            result = request.execute()
-            logging.info(f"{self.classname()}: Created class: {result}")
+            request_index[str(idx)] = request
+            remaining_requests.append((request, str(idx)))
+
+        def callback(request_id, response, exception):
+            """A local callback for batch requests when they have completed."""
+
+            if exception:
+                status = exception.resp.status
+                # 429: Quota exceeded.
+                # Add the original request back to retry later.
+                if status == 429:
+                    remaining_requests.append(request_index[request_id])
+                    nonlocal quota_exceeded
+                    quota_exceeded = True
+                logging.debug(exception)
+                return
+
+            if response and "warnings" in response:
+                for warning in response["warnings"]:
+                    logging.debug(f"{warning['code']}: {warning['message']}")
+
+            nonlocal batch_results
+            batch_results.append(response)
+
+        while len(remaining_requests) > 0:
+            logging.info(
+                f"{self.classname()}: {len(remaining_requests)} requests remaining."
+            )
+            batch = self.service.new_batch_http_request(callback=callback)
+            current_batch = 0
+            while len(remaining_requests) > 0 and current_batch < self.batch_size:
+                current_batch += 1
+                (request, request_id) = remaining_requests.pop()
+                batch.add(request, request_id=request_id)
+            self._execute_batch_with_retry(batch)
+
+            # Process the results of the batch.
+            logging.debug(
+                f"{self.classname()}: successfully created {len(batch_results)} items."
+            )
+
+            # Pause if quota exceeded. 20s because the quota is a sliding time window.
+            if quota_exceeded:
+                quota_exceeded = False
+                logging.info(
+                    f"{self.classname()}: Quota exceeded. Pausing for 20 seconds..."
+                )
+                time.sleep(20)
 
         return (to_create, to_delete)

--- a/google_classroom/endpoints/course.py
+++ b/google_classroom/endpoints/course.py
@@ -35,7 +35,7 @@ class Courses(EndPoint):
 
     def return_cleaned_sync_data(self):
         df = self.return_all_data().astype("str")
-        df = df[df["courseState"] == "ACTIVE"]
+        df = df[df["courseState"].isin(["ACTIVE", "PROVISIONED"])]
         df = df.rename(columns={"id": "courseId"})
         df = df[["courseId", "name", "section"]]
         return df.astype("str")

--- a/google_classroom/main.py
+++ b/google_classroom/main.py
@@ -120,7 +120,7 @@ def pull_data(config, creds, sql):
         or config.PULL_MEET
     ):
         courses = Courses(classroom_service, sql, config).return_all_data()
-        courses = courses[courses["courseState"] == "ACTIVE"]
+        courses = courses[courses["courseState"].isin(["ACTIVE", "PROVISIONED"])]
         course_ids = courses.id.unique()
 
     # Get course invitations


### PR DESCRIPTION
Fixes #87 
Depends on #101 

This PR adds batching logic for course creation. I tried a few different methods for reusing the existing logic before realizing that:
 - Without good testing on the batching logic itself, this ends up being very risky.
 - There are some substantial differences between the create endpoints and the list endpoints.

With that in mind, my new suggested approach is that we get batching working as it should be designed for create endpoints, write the tests, and then figure out a way to share the code between create/list endpoints.

I have tested this locally, and while batching creates is not particularly quick, it does work well. We will potentially need to have smaller batch size limits than the list endpoints if it becomes a problem.