### PR TITLE
Sync Teacher CSV

### DIFF
--- a/google_classroom/endpoints/teacher.py
+++ b/google_classroom/endpoints/teacher.py
@@ -12,6 +12,8 @@ class Teachers(EndPoint):
         ]
         self.request_key = "teachers"
         self.batch_size = config.TEACHERS_BATCH_SIZE
+        self.columns_to_merge_on = ["alias", "emailAddress"]
+        self.should_delete_on_sync = False
 
     def request_data(self, course_id=None, date=None, next_page_token=None):
         return (
@@ -29,3 +31,17 @@ class Teachers(EndPoint):
             record["fullName"] = record.get("profile").get("name").get("fullName")
             record["emailAddress"] = record.get("profile").get("emailAddress")
         return records
+
+    def create_new_item(self, teacher):
+        return (
+            self.service.courses()
+            .teachers()
+            .create(courseId=teacher["alias"], body={"userId": teacher["emailAddress"]})
+        )
+
+    def delete_item(self, teacher):
+        return (
+            self.service.courses()
+            .teachers()
+            .delete(courseId=teacher["courseId"], userId=teacher["userId"])
+        )

--- a/google_classroom/main.py
+++ b/google_classroom/main.py
@@ -164,6 +164,7 @@ def sync_all_data(config, creds, sql):
     classroom_service = build("classroom", "v1", credentials=creds)
     Courses(classroom_service, sql, config).sync_data()
     Students(classroom_service, sql, config).sync_data()
+    Teachers(classroom_service, sql, config).sync_data()
 
 
 if __name__ == "__main__":

--- a/google_classroom/sync_files/teachers_sample.csv
+++ b/google_classroom/sync_files/teachers_sample.csv
@@ -1,0 +1,4 @@
+alias,emailAddress
+99997,teacher1@gmail.com
+99998,teacher2@gmail.com
+99999,teacher1@gmail.com

--- a/tests/sync_data.py
+++ b/tests/sync_data.py
@@ -77,3 +77,38 @@ TO_DELETE_STUDENT_SOLUTION = pd.DataFrame(
         "fullName": ["User2", "User1", "User3"],
     }
 )
+
+# TEACHER SYNC DATA
+
+TEACHER_DATA = pd.DataFrame(
+    {
+        "courseId": ["1", "1", "2", "2"],
+        "userId": ["91", "92", "91", "93"],
+        "fullName": ["Teacher1", "Teacher2", "Teacher1", "Teacher3"],
+        "emailAddress": ["t1@a.com", "t2@a.com", "t1@a.com", "t3@a.com"],
+    }
+)
+
+TEACHER_SYNC_DATA = pd.DataFrame(
+    {
+        "alias": ["123", "234", "345"],
+        "emailAddress": ["t1@a.com", "t2@a.com", "t1@a.com"],
+    }
+)
+
+TO_CREATE_TEACHER_SOLUTION = pd.DataFrame(
+    {
+        "alias": ["d:234", "d:345"],
+        "emailAddress": ["t2@a.com", "t1@a.com"],
+    }
+)
+
+TO_DELETE_TEACHER_SOLUTION = pd.DataFrame(
+    {
+        "alias": ["d:123", "d:234", "d:234"],
+        "emailAddress": ["t2@a.com", "t1@a.com", "t3@a.com"],
+        "courseId": ["1", "2", "2"],
+        "userId": ["92", "91", "93"],
+        "fullName": ["Teacher2", "Teacher1", "Teacher3"],
+    }
+)

--- a/tests/test_all.py
+++ b/tests/test_all.py
@@ -39,12 +39,16 @@ from sync_data import (
     COURSE_DATA,
     ALIAS_DATA,
     STUDENT_DATA,
+    TEACHER_DATA,
     COURSE_SYNC_DATA,
     STUDENT_SYNC_DATA,
+    TEACHER_SYNC_DATA,
     TO_CREATE_COURSE_SOLUTION,
     TO_DELETE_COURSE_SOLUTION,
     TO_CREATE_STUDENT_SOLUTION,
     TO_DELETE_STUDENT_SOLUTION,
+    TO_CREATE_TEACHER_SOLUTION,
+    TO_DELETE_TEACHER_SOLUTION,
 )
 
 
@@ -189,3 +193,17 @@ class TestSync:
         courses._drop_table()
         aliases._drop_table()
         students._drop_table()
+
+    def test_sync_teachers(self):
+        courses = Courses(self.service, self.sql, self.config)
+        aliases = CourseAliases(self.service, self.sql, self.config)
+        teachers = Teachers(self.service, self.sql, self.config)
+        self.sql.insert_into(courses.table_name, COURSE_DATA)
+        self.sql.insert_into(aliases.table_name, ALIAS_DATA)
+        self.sql.insert_into(teachers.table_name, TEACHER_DATA)
+        (to_create, to_delete) = teachers.sync_data(TEACHER_SYNC_DATA)
+        assert to_create.equals(TO_CREATE_TEACHER_SOLUTION)
+        assert to_delete.equals(TO_DELETE_TEACHER_SOLUTION)
+        courses._drop_table()
+        aliases._drop_table()
+        teachers._drop_table()


### PR DESCRIPTION
Depends on #109 
Fixes #88

Adds support for syncing a CSV of teachers, heavily based on the logic of syncing students (the APIs are effectively the same).