### PR TITLE
Fixes for Google Classroom missing data

### DIFF
--- a/google_classroom/endpoints/announcement.py
+++ b/google_classroom/endpoints/announcement.py
@@ -30,3 +30,9 @@ class Announcements(EndPoint):
                 pageSize=self.config.PAGE_SIZE,
             )
         )
+
+    def preprocess_records(self, records):
+        for record in records:
+            if "text" in record:
+                record["text"] = record["text"].replace("\x00", "")
+        return records

--- a/google_classroom/endpoints/base.py
+++ b/google_classroom/endpoints/base.py
@@ -195,8 +195,10 @@ class EndPoint:
                     )
                     remaining_requests.append(same_request)
                     nonlocal quota_exceeded
+                    if not quota_exceeded:
+                        # Only log once to avoid spaminess.
+                        logging.debug(exception)
                     quota_exceeded = True
-                logging.debug(exception)
                 return
 
             if "warnings" in response:

--- a/google_classroom/endpoints/student_usage.py
+++ b/google_classroom/endpoints/student_usage.py
@@ -1,3 +1,4 @@
+import logging
 import pandas as pd
 from datetime import datetime
 
@@ -41,11 +42,15 @@ class StudentUsage(EndPoint):
             row = {}
             row["Email"] = record.get("entity").get("userEmail")
             row["AsOfDate"] = record.get("date")
-            row["LastUsedTime"] = self._get_date_from_params(record.get("parameters"))
+            row["LastUsedTime"] = self._get_date_from_record(record)
             row["ImportDate"] = datetime.today().strftime("%Y-%m-%d")
             new_records.append(row)
         return new_records
 
-    def _get_date_from_params(self, parameters):
+    def _get_date_from_record(self, record):
+        if "parameters" not in record:
+            logging.debug(f"{self.classname()}: Parameters not in record {record}.")
+        parameters = record.get("parameters", [])
         for parameter in parameters:
             return parameter.get("datetimeValue")
+        return "1970-01-01T00:00:00.00Z"


### PR DESCRIPTION
Fixes a few issues I'm coming across from various Google Classroom data:

 - Having the character "\x00" in announcements, which is a NULL character and has problems saving to a DB.
 - Missing a date in a student usage record, which will now default to 1970 (what Google uses when someone hasn't logged in yet).