### PR TITLE
Fix Black v20.8 errors

### DIFF
--- a/google_classroom/endpoints/base.py
+++ b/google_classroom/endpoints/base.py
@@ -304,7 +304,7 @@ class EndPoint:
             both:       A dataframe containing data found in both df1 and df2.
         """
         merged = pd.merge(
-            df1, df2, left_on=left_on, right_on=right_on, how="outer", indicator=True,
+            df1, df2, left_on=left_on, right_on=right_on, how="outer", indicator=True
         )
         left_only = merged[merged["_merge"] == "left_only"].reset_index(drop=True)
         right_only = merged[merged["_merge"] == "right_only"].reset_index(drop=True)

--- a/google_classroom/endpoints/course.py
+++ b/google_classroom/endpoints/course.py
@@ -27,7 +27,7 @@ class Courses(EndPoint):
 
     def request_data(self, course_id=None, date=None, next_page_token=None):
         return self.service.courses().list(
-            pageToken=next_page_token, pageSize=self.config.PAGE_SIZE,
+            pageToken=next_page_token, pageSize=self.config.PAGE_SIZE
         )
 
     def filter_data(self, dataframe):


### PR DESCRIPTION
I think the problem you were running into with Black is that the test runner doesn't use a locked version of Black, so when a new version came out that required more changes, the test started failing. I am on the latest version of Black (v20.8) and similarly it wants to format the same two files.

This fixes the new Black errors (I think the new version requires that when the parameters have a trailing comma, it should always split it into separate lines per parameter).