### PR TITLE
Add runtime args list to mailer

### DIFF
--- a/google_classroom/main.py
+++ b/google_classroom/main.py
@@ -183,6 +183,5 @@ if __name__ == "__main__":
         logging.exception(e)
         error_message = traceback.format_exc()
     if not Config.DISABLE_MAILER:
-        Mailer(Config, f"Google Classroom Connector{get_args()}").notify(
-            error_message=error_message
-        )
+        jobname = f"Google Classroom Connector{get_args()}"
+        Mailer(Config, jobname).notify(error_message=error_message)

--- a/google_classroom/main.py
+++ b/google_classroom/main.py
@@ -166,6 +166,14 @@ def sync_all_data(config, creds, sql):
     print("Data syncing is not yet available.")
 
 
+def get_args():
+    """ Return list of runtime args for use in mailer notifications"""
+    args = sys.argv
+    args = args[1:]
+    args = [arg.replace("--", "") for arg in args]
+    return ", ".join(args)
+
+
 if __name__ == "__main__":
     try:
         main(Config)
@@ -174,4 +182,6 @@ if __name__ == "__main__":
         logging.exception(e)
         error_message = traceback.format_exc()
     if not Config.DISABLE_MAILER:
-        Mailer(Config, "Google Classroom Connector").notify(error_message=error_message)
+        Mailer(Config, f"Google Classroom Connector: {get_args()}").notify(
+            error_message=error_message
+        )

--- a/google_classroom/main.py
+++ b/google_classroom/main.py
@@ -168,10 +168,11 @@ def sync_all_data(config, creds, sql):
 
 def get_args():
     """ Return list of runtime args for use in mailer notifications"""
-    args = sys.argv
-    args = args[1:]
+    args = sys.argv[1:]
     args = [arg.replace("--", "") for arg in args]
-    return ", ".join(args)
+    args = ", ".join(args)
+    prefix = ": " if args else ""
+    return f"{prefix}{args}"
 
 
 if __name__ == "__main__":
@@ -182,6 +183,6 @@ if __name__ == "__main__":
         logging.exception(e)
         error_message = traceback.format_exc()
     if not Config.DISABLE_MAILER:
-        Mailer(Config, f"Google Classroom Connector: {get_args()}").notify(
+        Mailer(Config, f"Google Classroom Connector{get_args()}").notify(
             error_message=error_message
         )


### PR DESCRIPTION
This adds the list of runtime args to the mailer notifications so when the job is run different ways it is easier to tell which ones have succeeded or failed. I.E. was it the coursework or submissions run that failed?